### PR TITLE
fix: image zoom interaction on space key

### DIFF
--- a/src/presentation/logic/InteractionOrchestrator.ts
+++ b/src/presentation/logic/InteractionOrchestrator.ts
@@ -251,7 +251,7 @@ export class InteractionOrchestrator {
 
   private startEditing(element: HTMLElement, nodeId: string): void {
     const node = this.mindMap?.findNode(nodeId);
-    if (node && node.image) {
+    if (node && (node.thumbnail || node.image)) {
       this.zoomNode(nodeId);
       return;
     }


### PR DESCRIPTION
Fixes issue where space key triggers text edit instead of zoom for image nodes.